### PR TITLE
Connect fe

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,12 +217,8 @@ GEM
       rspec-support (~> 3.13)
     rspec-support (3.13.2)
     securerandom (0.4.1)
-    simplecov (0.22.0)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.13.1)
-    simplecov_json_formatter (0.1.4)
+    shoulda-matchers (6.4.0)
+      activesupport (>= 5.2.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -261,6 +257,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 7.1.5, >= 7.1.5.1)
   rspec-rails
+  shoulda-matchers
   simplecov
   tzinfo-data
 

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::ItemsController < ApplicationController
+  def index
+    
+  end
+end

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::MerchantsController < ApplicationController
+  def index
+   merchants = Merchant.all
+   render json: merchants
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,5 +1,5 @@
 class Invoice < ApplicationRecord
   belongs_to :customer
-  belongs_to :merchants
+  belongs_to :merchant
   has_many :invoice_items
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -1,4 +1,4 @@
-class Invoice_item < ApplicationRecord
+class InvoiceItem < ApplicationRecord
   belongs_to :invoice
   belongs_to :item
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -14,3 +14,12 @@
 #       methods: [:get, :post, :put, :patch, :delete, :options, :head]
 #   end
 # end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "localhost:5173"
+
+    resource "*",
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,8 @@ Rails.application.routes.draw do
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
-
+  
+  get "/api/v1/merchants", to: "api/v1/merchants#index"
   # Defines the root path route ("/")
   # root "posts#index"
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -1,7 +1,9 @@
-describe Invoice_item, type: :model do
+require 'rails_helper'
+
+describe InvoiceItem, type: :model do
   describe "relationships" do
-    it { should belongs_to :invoice }
-    it { should belongs_to :item}
+    it { should belong_to :invoice }
+    it { should belong_to :item}
   end
 end
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1,8 +1,10 @@
-describe Invoice_spec, type: :model do
+require 'rails_helper'
+
+describe Invoice, type: :model do
   describe "relationships" do
     it { should have_many :invoice_items }
-    it {belongs_to :customer}
-    it {belongs_to :merchants}
+    it {belong_to :customer}
+    it {belong_to :merchant}
   end
 end
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,7 +1,9 @@
+require 'rails_helper'
+
 describe Item, type: :model do
   describe "relationships" do
-    it { belongs_to :merchants }
-    it { has_many :invoice_items }
+    it { belong_to :merchants }
+    it { have_many :invoice_items }
   end
 end
 

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -1,7 +1,9 @@
+require 'rails_helper'
+
 describe Merchant, type: :model do
   describe "relationships" do
-    it { has_many :invoices }
-    it { has_many :items }
+    it { have_many :invoices }
+    it { have_many :items }
   end 
 end
 

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -1,6 +1,8 @@
+require 'rails_helper'
+
 describe Transaction, type: :model do
   describe "relationships" do
-    it { belongs_to :invoice }
+    it { belong_to :invoice }
   end
 end
 


### PR DESCRIPTION
Added: 
- code to connect FE
- Invoice model: belongs_to :merchant (singular) because an invoice belongs to one customer and one merchant.
- Removed underscore from the invoice-items class and changed to camel case => InvoiceItem.
- All Rspec files should use belong_to, not belongs_to.
- All Rspec files should use have_many, not has_many.
- route for get all merchants 
- index method for merchant controller
- created items controller 